### PR TITLE
Minimize lodash deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/pirosikick/redux-throttle-actions/issues"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash.throttle": "4.0.1",
+    "lodash.isarray": "4.0.0"
   },
   "devDependencies": {
     "babel": "^6.0.15",


### PR DESCRIPTION
With Lodash 4, you can target specific modules to minimize on overhead.
- [lodash.throttle](https://www.npmjs.com/package/lodash.throttle)
- [lodash.isarray](https://www.npmjs.com/package/lodash.isarray)
